### PR TITLE
Pass deployment metadata when creating status

### DIFF
--- a/github-deploy/bin/deployment-create-status
+++ b/github-deploy/bin/deployment-create-status
@@ -1,9 +1,27 @@
 #!/bin/sh
+#
+# Usage:
+#   deployment-create-status <state> <description>
+#
+# Arguments:
+#   $1 - The deployment state
+#   $2 - The deployment description
+#
 
 BASEDIR=$(dirname "$0")
 DEPLOYMENT_ID=$("${BASEDIR}"/deployment-get-id)
+GITHUB_URL="https://github.com"
+GITHUB_API_URL="https://api.github.com"
 
 echo "Setting status to ${1} for deployment-id '${DEPLOYMENT_ID}'"
-curl --silent --show-error --fail -X POST -H "Authorization: token ${GITHUB_TOKEN}" \
-    --data '{"state":"'"${1}"'"}' \
-    "https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses"
+curl --silent --show-error --fail \
+    -X POST "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Content-Type: text/json; charset=utf-8" \
+    -d @- <<EOF
+{
+    "state": "${1}",
+    "target_url": "${GITHUB_URL}/${GITHUB_REPOSITORY}/actions",
+    "description": "${2}"
+}
+EOF

--- a/github-deploy/bin/deployment-create-status
+++ b/github-deploy/bin/deployment-create-status
@@ -13,15 +13,20 @@ DEPLOYMENT_ID=$("${BASEDIR}"/deployment-get-id)
 GITHUB_URL="https://github.com"
 GITHUB_API_URL="https://api.github.com"
 
-echo "Setting status to ${1} for deployment-id '${DEPLOYMENT_ID}'"
+DEPLOY_STATE="${1}"
+DEPLOY_DESC="${2}"
+
+[ -n "${DEPLOY_DESC}" ] || DEPLOY_DESC="Deploying from GitHub Actions"
+
+echo "Setting status to ${DEPLOY_STATE} for deployment-id '${DEPLOYMENT_ID}'"
 curl --silent --show-error --fail \
     -X POST "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Content-Type: text/json; charset=utf-8" \
     -d @- <<EOF
 {
-    "state": "${1}",
+    "state": "${DEPLOY_STATE}",
     "target_url": "${GITHUB_URL}/${GITHUB_REPOSITORY}/actions",
-    "description": "${2}"
+    "description": "${DEPLOY_DESC}"
 }
 EOF


### PR DESCRIPTION
Some minor enhancements for creating deployment statuses:

- Sets [target_url](https://developer.github.com/v3/repos/deployments/#parameters-2) to /actions since GitHub [does not yet provide action run id](https://github.community/t5/GitHub-API-Development-and/Github-Actions-url-to-run/m-p/16471#M506)
- Ability to pass a description
- Format post parameters

Instead of `log_url`, we pass `target_url`, so we don't need to rely on [experimental features](https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/#link-to-a-live-deployment). 