### PR TITLE
Enable sending `in_progress` status and set deployment status to `failure`

### DIFF
--- a/github-deploy/bin/deployment-create-status
+++ b/github-deploy/bin/deployment-create-status
@@ -9,7 +9,7 @@
 #
 
 BASEDIR=$(dirname "$0")
-DEPLOYMENT_ID=$("${BASEDIR}"/deployment-get-id)
+#DEPLOYMENT_ID=$("${BASEDIR}"/deployment-get-id)
 GITHUB_URL="https://github.com"
 GITHUB_API_URL="https://api.github.com"
 
@@ -23,6 +23,7 @@ curl --silent --show-error --fail \
     -X POST "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/deployments/${DEPLOYMENT_ID}/statuses" \
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Content-Type: text/json; charset=utf-8" \
+    -H "Accept: application/vnd.github.flash-preview+json" \
     -d @- <<EOF
 {
     "state": "${DEPLOY_STATE}",

--- a/github-deploy/bin/deployment-create-status
+++ b/github-deploy/bin/deployment-create-status
@@ -9,7 +9,7 @@
 #
 
 BASEDIR=$(dirname "$0")
-#DEPLOYMENT_ID=$("${BASEDIR}"/deployment-get-id)
+DEPLOYMENT_ID=$("${BASEDIR}"/deployment-get-id)
 GITHUB_URL="https://github.com"
 GITHUB_API_URL="https://api.github.com"
 

--- a/github-deploy/bin/deployment-exec-try
+++ b/github-deploy/bin/deployment-exec-try
@@ -6,6 +6,6 @@ sh -c "$*"
 RESULT=$?
 if [ 0 != "${RESULT}" ];then
     echo "Failed '$*'! Exit code '${RESULT}' is not equal to 0"
-    "${BASEDIR}"/deployment-create-status error
+    "${BASEDIR}"/deployment-create-status failure
     exit ${RESULT}
 fi


### PR DESCRIPTION
To enable setting the `in_progress` status the `Accept` header must include `application/vnd.github.flash-preview+json`.

Also setting `status` to `failure` in `deployment-exec-try`, since it better fits the semantics. Error is described as "completed, but with errors", in most cases when one step fails, the entire deployment should be set to failing.