### PR TITLE
Adding support to get payload parameters and to get the deploy task

### DIFF
--- a/github-deploy/bin/deployment-get-payload
+++ b/github-deploy/bin/deployment-get-payload
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-if [[ -z "$1" ]] ; then
+if [ -z "$1" ] ; then
   echo "Payload argument  must be set. Usage: deployment-get-payload <payload>"
   exit 64
 fi

--- a/github-deploy/bin/deployment-get-payload
+++ b/github-deploy/bin/deployment-get-payload
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+BASEDIR=$(dirname "$0")
+_payload_field=$1
+"${BASEDIR}"/JSON.sh < "${GITHUB_EVENT_PATH}" | grep "\[\"deployment\",\"payload\",\"config\",\"${_payload_field}\"]" | cut -f2 | sed -e 's/^"//' -e 's/"$//'

--- a/github-deploy/bin/deployment-get-payload
+++ b/github-deploy/bin/deployment-get-payload
@@ -1,5 +1,11 @@
 #!/bin/sh
+set -e
+if [[ -z "$1" ]] ; then
+  echo "Payload argument  must be set. Usage: deployment-get-payload <payload>"
+  exit 64
+fi
 
 BASEDIR=$(dirname "$0")
 _payload_field=$1
+
 "${BASEDIR}"/JSON.sh < "${GITHUB_EVENT_PATH}" | grep "\[\"deployment\",\"payload\",\"config\",\"${_payload_field}\"]" | cut -f2 | sed -e 's/^"//' -e 's/"$//'

--- a/github-deploy/bin/deployment-get-task
+++ b/github-deploy/bin/deployment-get-task
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+BASEDIR=$(dirname "$0")
+"${BASEDIR}"/JSON.sh < "${GITHUB_EVENT_PATH}" | grep "\[\"deployment\",\"task\"]" | cut -f2 | sed -e 's/^"//' -e 's/"$//'


### PR DESCRIPTION
If one uses `hubot-deploy` you can send arbitrary fields as a payload, this PR enables you to pull the payload fields by using `deployment-get-payload <field_name>`. Does not work for nested fields.

PR also adds the ability to get the deploy task as sent by `hubot-deploy`.